### PR TITLE
Fix wrong allocation size of ringbuffer

### DIFF
--- a/ringbuffer/ringbuffer.c
+++ b/ringbuffer/ringbuffer.c
@@ -54,8 +54,9 @@ typedef struct {
 /* true if x is a power of 2 */
 #define IS_POWEROF2(x) ((((x) -1) & (x)) == 0)
 #define RING_SIZE_MASK (unsigned) (0x0fffffff) /**< Ring size mask */
-#define ALIGN_FLOOR(val, align) \
-    (typeof(val))((val) & (~((typeof(val))((align) -1))))
+#define ALIGN_CEIL(val, align) \
+    (typeof(val))((val) + (-(typeof(val))(val) & ((align) -1)))
+
 
 /**
  * Calculate the memory size needed for a ring buffer.
@@ -80,7 +81,7 @@ ssize_t ringbuf_get_memsize(const unsigned count)
         return -EINVAL;
 
     ssize_t sz = sizeof(ringbuf_t) + count * sizeof(void *);
-    sz = ALIGN_FLOOR(sz, CACHE_LINE_SIZE);
+    sz = ALIGN_CEIL(sz, CACHE_LINE_SIZE);
     return sz;
 }
 


### PR DESCRIPTION
I'm not sure why the actual size is calculated by `ALIGN_FLOOR`. 

Since the constraint of `count` is that it must be the power of 2, so it is valid to be like 2 or 4. However, in these cases, `ALIGN_FLOOR` won't allocate any size for `*ring[]` in `ringbuf_t` when `CACHE_LINE_SIZE == 64`. It makes the overflow access of memory which can be detected by valgrind or ASAN. So I think `ALIGN_CEIL`  should be the correct one in general?  Do I miss some reason for using `ALIGN_FLOOR`?