### PR TITLE
Remove legacy __sync_fetch_and_add with __atomic_fetch_add 

### DIFF
--- a/qsbr/main.c
+++ b/qsbr/main.c
@@ -5,7 +5,7 @@
 #define unlikely(x) __builtin_expect((x) != 0, 0)
 
 #ifndef atomic_fetch_add
-#define atomic_fetch_add(x, a) __sync_fetch_and_add(x, a)
+#define atomic_fetch_add(x, a) __atomic_fetch_add(x, a, __ATOMIC_SEQ_CST)
 #endif
 
 #ifndef atomic_thread_fence


### PR DESCRIPTION
__ATOMIC_SEQ_CST was picked to enforce total ordering with all other __ATOMIC_SEQ_CST operations.)