### PR TITLE
Correct the range for modulo

### DIFF
--- a/mpmc/mpmc.c
+++ b/mpmc/mpmc.c
@@ -160,7 +160,7 @@ static void *mpmc_find_cell(node_t *volatile *ptr, long i, handle_t *th)
     __asm("sfence" ::: "cc", "memory"); /* FIXME: x86-only */
 
     /* now we get the needed cell, its' node is curr and index is i % N */
-    return &curr->cells[i & N];
+    return &curr->cells[i & NBITS];
 }
 
 #include <linux/futex.h>


### PR DESCRIPTION
The value `N` is power of 2 integer which is declared in :
```cpp
#define N (1 << 12) /* node size */
#define NBITS (N - 1)
```
`N` will become  `1 0000 0000 0000` in binary.
When the divisor `N` is power of 2, the operator `%` is equal to logical AND with `N - 1`
which means that  i mod 2^n with bitwise AND is ( i & N - 1 ) not ( i & N ).

For example: 
`3 % 4 == 3 == 0011 % 0100 == 0011 & ( 0100 - 1 )`
