### PR TITLE
Add more operation analysis, combine with deletes and inserts variables.

### DIFF
--- a/hp_list/Makefile
+++ b/hp_list/Makefile
@@ -12,6 +12,11 @@ $(BIN): main.c
 all: CFLAGS += -O2
 all: $(BIN)
 
+# Once RUNTIME_STAT is defined, the program will show runtime states in
+# statistics.
+analyze: CFLAGS +=-D RUNTIME_STAT
+analyze: $(BIN)
+
 indent:
 	clang-format -i *.[ch]
 

--- a/hp_list/README.md
+++ b/hp_list/README.md
@@ -1,0 +1,16 @@
+# Concurrent Linked List With Hazard Pointer
+
+## Runtime States In Statistics
+
+Following are the explanation of variables, when `RUNTIME_STAT` defined :
+
+* **retry**    is the number of retries in the __list_find function.
+* **contains** is the number of wait-free contains in the __list_find function that curr pointer pointed.
+* **traversal** is the number of list element traversal in the __list_find function.
+* **fail**     is the number of CAS() failures.
+* **del**      is the number of list_delete operation failed and restart again.
+* **ins**      is the number of list_insert operation failed and restart again.
+* **deletes**  is the number of linked list elements deleted.
+* **inserts**  is the number of linked list elements created.
+* **load**     is the number of atomic_load operation in list_delete, list_insert and __list_find.
+* **store**    is the number of atomic_store operation in list_delete, list_insert and __list_find.


### PR DESCRIPTION
Add more operation analysis, combine with deletes and inserts variables.
And Using the preprocessor to decide the analysis being set or not.

For example:
```
retry     : 187
contains  : 0
traversal : 21028166
fail      : 0
del       : 0
ins       : 0
load      : 63167962
store     : 4096
deletes   : 4098
inserts   : 4098
"retry"    is the number of retries in the __list_find function.
"contains" is the number of wait-free contains in the __list_find function that curr pointer pointed.
"traversal"is the number of list element traversal in the __list_find function.
"fail"     is the number of CAS() failures.
"del"      is the number of list_delete operation failed and restart again.
"ins"      is the number of list_insert operation failed and restart again.
"deletes"  is the number of linked list elements deleted.
"inserts"  is the number of linked list elements created.
"load"     is the number of atomic_load operation in list_delete, list_insert and __list_find.
"store"    is the number of atomic_store operation in list_delete, list_insert and __list_find.
```

The following are the new variables to record the operations:
rtry is the number of retries in the __list_find function.
cons is the number of wait-free contains in the __list_find function that curr pointer pointed.
trav is the number of list element traversal in the __list_find function.
fail is the number of CAS() failures.
del  is the number of list_delete operation failed and restart again.
ins  is the number of list_insert operation failed and restart again.