### PR TITLE
Fix bug in list_hp_retire function

### DIFF
--- a/hp_list/main.c
+++ b/hp_list/main.c
@@ -234,7 +234,7 @@ void list_hp_retire(list_hp_t *hp, uintptr_t ptr)
     if (rl->size < HP_THRESHOLD_R)
         return;
 
-    for (size_t iret = 0; iret < rl->size; iret++) {
+    for (size_t iret = 0; iret < rl->size;) {
         uintptr_t obj = rl->list[iret];
         bool can_delete = true;
         for (int itid = 0; itid < HP_MAX_THREADS && can_delete; itid++) {
@@ -251,6 +251,8 @@ void list_hp_retire(list_hp_t *hp, uintptr_t ptr)
             memmove(&rl->list[iret], &rl->list[iret + 1], bytes);
             rl->size--;
             hp->deletefunc((void *) obj);
+        } else {
+            iret++;
         }
     }
 }


### PR DESCRIPTION
In hp_list project's function : _list_hp_retire_, it attempt to reorganize retire list while the object is deleting.
However, as I see, the origin code doesn't adjust the index simultaneously, which will skip track of the object
origin from _&rl->list[iret + 1]_. I'm not sure whether the behavior was originally intended or not.