### PR TITLE
Add thread-based RCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ purpose of these programs is to be illustrative and educational.
     - [qsbr](qsbr/): An implementation of Quiescent state based reclamation (QSBR).
     - [list-move](list-move/): Evaluation of two concurrent linked lists: QSBR and lock-based.
     - [rcu\_queue](rcu_queue/): An efficient concurrent queue based on QSBR.
+    - [thread-rcu](thread-rcu/): A Linux Kernel style thread-based simple RCU.
 * Applications
     - [httpd](httpd/): A multi-threaded web server.
     - [map-reduce](map-reduce/): word counting using MapReduce.

--- a/thread-rcu/Makefile
+++ b/thread-rcu/Makefile
@@ -1,0 +1,31 @@
+CFLAGS = -Wall
+CFLAGS += -g
+CFLAGS += -std=c11
+CFLAGS += -D'N_READERS=100'
+CFLAGS += -D'N_UPDATE_RUN=5'
+CFLAGS += -fsanitize=thread
+LDFLAGS += -lpthread
+
+# The pthread mutex initializer will warning:
+# thrd_rcu.h:95:42: warning: Using plain integer as NULL pointer
+# We can ignore it.
+SPARSE_FLAGS = -Wno-non-pointer-null
+
+main: main.c rcu.h
+	$(CC) -o $@ $< $(CFLAGS) $(LDFLAGS)
+
+clang: CC=clang
+clang: main
+
+all: main
+
+# Semantic Checker
+# https://www.kernel.org/doc/html/latest/dev-tools/sparse.html
+sparse:
+	sparse main.c $(CFLAGS) $(SPARSE_FLAGS)
+
+indent:
+	clang-format -i *.[ch]
+
+clean:
+	rm -f main

--- a/thread-rcu/README.md
+++ b/thread-rcu/README.md
@@ -1,0 +1,4 @@
+# Thread-Local Storage Based Read-Copy Update
+
+The Linux Kernel style of Read-Copy Update.
+It uses thread-local storage to optimize the read-side lock overhead.

--- a/thread-rcu/main.c
+++ b/thread-rcu/main.c
@@ -1,0 +1,147 @@
+#include <pthread.h>
+#include <stdatomic.h>
+
+struct barrier_struct {
+    atomic_int flag;
+    int count;
+    pthread_mutex_t lock;
+};
+
+static __thread int local_sense = 0;
+
+#define BARRIER_INIT                                             \
+    {                                                            \
+        .flag = 0, .count = 0, .lock = PTHREAD_MUTEX_INITIALIZER \
+    }
+
+#define DEFINE_BARRIER(name) struct barrier_struct name = BARRIER_INIT
+
+static inline void thread_barrier(struct barrier_struct *b, size_t n)
+{
+    local_sense = !local_sense;
+
+    pthread_mutex_lock(&b->lock);
+    b->count++;
+    if (b->count == n) {
+        pthread_mutex_unlock(&b->lock);
+        atomic_store_explicit(&b->flag, local_sense, memory_order_release);
+    } else {
+        pthread_mutex_unlock(&b->lock);
+        while (atomic_load_explicit(&b->flag, memory_order_acquire) !=
+               local_sense)
+            ;
+    }
+}
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rcu.h"
+
+#define GP_IDX_MAX N_UPDATE_RUN + 1
+
+static DEFINE_BARRIER(test_barrier);
+
+struct test {
+    unsigned int count;
+};
+static struct test __rcu *dut;
+static atomic_uint gp_idx;
+static atomic_uint prev_count;
+static atomic_uint grace_periods[GP_IDX_MAX];
+
+static void *reader_func(void *argv)
+{
+    struct test *tmp;
+    unsigned int old_prev_count;
+
+    if (rcu_init())
+        abort();
+
+    thread_barrier(&test_barrier, N_READERS + 1);
+
+    rcu_read_lock();
+
+    tmp = rcu_dereference(dut);
+
+    if (tmp->count != atomic_load_explicit(&prev_count, memory_order_acquire)) {
+        old_prev_count = atomic_exchange_explicit(&prev_count, tmp->count,
+                                                  memory_order_release);
+        if (tmp->count != old_prev_count)
+            atomic_fetch_add_explicit(&gp_idx, 1, memory_order_release);
+        if (atomic_load_explicit(&gp_idx, memory_order_acquire) >
+            N_UPDATE_RUN + 1) {
+            fprintf(stderr, "grace period index (%u) is over bound (%u).\n",
+                    atomic_load_explicit(&gp_idx, memory_order_acquire),
+                    N_UPDATE_RUN);
+            abort();
+        }
+    }
+
+    atomic_fetch_add_explicit(
+        &grace_periods[atomic_load_explicit(&gp_idx, memory_order_acquire)], 1,
+        memory_order_relaxed);
+
+    rcu_read_unlock();
+
+    pthread_exit(NULL);
+}
+
+static void *updater_func(void *argv)
+{
+    struct test *oldp;
+    struct test *newval;
+    unsigned int i = 0;
+
+    thread_barrier(&test_barrier, N_READERS + 1);
+    atomic_thread_fence(memory_order_seq_cst);
+
+    while (i++ < N_UPDATE_RUN) {
+        newval = malloc(sizeof(struct test));
+        newval->count = i;
+        oldp = rcu_assign_pointer(dut, newval);
+        synchronize_rcu();
+        free(oldp);
+    }
+
+    pthread_exit(NULL);
+}
+
+int main(int argc, char *argv[])
+{
+    pthread_t reader[N_READERS];
+    pthread_t updater;
+    unsigned int i, total = 0;
+
+    dut = (struct test __rcu *) malloc(sizeof(struct test));
+    rcu_uncheck(dut)->count = 0;
+
+    for (i = 0; i < N_READERS; i++)
+        pthread_create(&reader[i], NULL, reader_func, NULL);
+    pthread_create(&updater, NULL, updater_func, NULL);
+
+    for (i = 0; i < N_READERS; i++)
+        pthread_join(reader[i], NULL);
+    pthread_join(updater, NULL);
+
+    free(rcu_uncheck(dut));
+    rcu_clean();
+
+    atomic_thread_fence(memory_order_seq_cst);
+
+    printf("%u reader(s), %u update run(s), %u grace period(s)\n", N_READERS,
+           N_UPDATE_RUN, gp_idx + 1);
+    for (i = 0; i < gp_idx + 1; i++) {
+        printf("[grace period #%u] %4u reader(s)\n", i, grace_periods[i]);
+        total += grace_periods[i];
+    }
+
+    if (total != N_READERS)
+        fprintf(stderr,
+                "The Sum of records in the array of grace period(s) (%u) is "
+                "not the same with number of reader(s) (%u)\n",
+                total, N_READERS);
+
+    return 0;
+}

--- a/thread-rcu/rcu.h
+++ b/thread-rcu/rcu.h
@@ -1,0 +1,326 @@
+/* Target to use Linux Kernel Memory Model (LKMM) for thread-rcu,
+ * C11 memory model might be not compatible with LKMM.
+ * Be careful about the architecture or OS you use.
+ * You can check the paper to see more detail:
+ *
+ * http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0124r6.html
+ */
+
+#ifndef __RCU_H__
+#define __RCU_H__
+
+/* lock primitives derived from POSIX Threads and compiler primitives */
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef pthread_mutex_t spinlock_t;
+
+#define SPINLOCK_INIT PTHREAD_MUTEX_INITIALIZER
+static inline void spin_lock(spinlock_t *sp)
+{
+    int ret;
+
+    ret = pthread_mutex_lock(sp);
+    if (ret != 0) {
+        fprintf(stderr, "spin_lock:pthread_mutex_lock %d\n", ret);
+        abort();
+    }
+}
+
+static inline void spin_unlock(spinlock_t *sp)
+{
+    int ret;
+
+    ret = pthread_mutex_unlock(sp);
+    if (ret != 0) {
+        fprintf(stderr, "spin_unlock:pthread_mutex_unlock %d\n", ret);
+        abort();
+    }
+}
+
+#define current_tid() (uintptr_t) pthread_self()
+
+/* Be careful here, since the C11 terms do no have the same sequential
+ * consistency for the smp_mb(). Here we use the closely C11 terms,
+ * memory_order_seq_cst.
+ */
+#define smp_mb() atomic_thread_fence(memory_order_seq_cst)
+
+/* Compiler barrier, preventing the compiler from reordering memory accesses */
+#define barrier() __asm__ __volatile__("" : : : "memory")
+
+/* To access the shared variable use READ_ONCE() and WRITE_ONCE(). */
+
+/* READ_ONCE() close to those of a C11 volatile memory_order_relaxed atomic
+ * read. However, for address, data, or control dependency chain, it is more
+ * like memory_order_consume. But, presently most of implementations promote
+ * those kind of thing to memory_order_acquire.
+ */
+#define READ_ONCE(x)                                                      \
+    ({                                                                    \
+        barrier();                                                        \
+        __typeof__(x) ___x = atomic_load_explicit(                        \
+            (volatile _Atomic __typeof__(x) *) &x, memory_order_consume); \
+        barrier();                                                        \
+        ___x;                                                             \
+    })
+
+/* WRITE_ONCE() quite close to C11 volatile memory_order_relaxed atomic store */
+#define WRITE_ONCE(x, val)                                                  \
+    do {                                                                    \
+        atomic_store_explicit((volatile _Atomic __typeof__(x) *) &x, (val), \
+                              memory_order_relaxed);                        \
+    } while (0)
+
+#define smp_store_release(x, val)                                           \
+    do {                                                                    \
+        atomic_store_explicit((volatile _Atomic __typeof__(x) *) &x, (val), \
+                              memory_order_release);                        \
+    } while (0)
+
+#define atomic_fetch_add_release(x, v)                       \
+    ({                                                       \
+        __typeof__(*x) __a_a_r_x;                            \
+        atomic_fetch_add_explicit(                           \
+            (volatile _Atomic __typeof__(__a_a_r_x) *) x, v, \
+            memory_order_release);                           \
+    })
+
+#define atomic_fetch_or_release(x, v)                                          \
+    ({                                                                         \
+        __typeof__(*x) __a_r_r_x;                                              \
+        atomic_fetch_or_explicit((volatile _Atomic __typeof__(__a_r_r_x) *) x, \
+                                 v, memory_order_release);                     \
+    })
+
+#define atomic_xchg_release(x, v)                                              \
+    ({                                                                         \
+        __typeof__(*x) __a_c_r_x;                                              \
+        atomic_exchange_explicit((volatile _Atomic __typeof__(__a_c_r_x) *) x, \
+                                 v, memory_order_release);                     \
+    })
+
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#ifdef __CHECKER__
+#define __rcu __attribute__((noderef, address_space(__rcu)))
+#define rcu_check_sparse(p, space) ((void) (((typeof(*p) space *) p) == p))
+#define __force __attribute__((force))
+#define rcu_uncheck(p) ((__typeof__(*(p)) __force *) (p))
+#define rcu_check(p) ((__typeof__(*(p)) __force __rcu *) (p))
+#else
+#define __rcu
+#define rcu_check_sparse(p, space)
+#define __force
+#define rcu_uncheck(p) p
+#define rcu_check(p) p
+#endif /* __CHECKER__ */
+
+/* Avoid false sharing */
+#define CACHE_LINE_SIZE 64
+#define __rcu_aligned __attribute__((aligned(2 * CACHE_LINE_SIZE)))
+
+/* Per-thread variable
+ *
+ * rcu_nesting is to distinguish where the current thread is in which grace
+ * period. The reader will use the global variable rcu_nesting_idx to set up
+ * the corresponding index of rcu_nesting for the read-side critical section.
+ * It is a per-thread variable for optimizing the reader-side lock execution.
+ *
+ * rcu_nesting uses two lowest bits of __next_rcu_nesting to determine the
+ * grace period. Do not use __next_rcu_nesting directly. Use the helper macro
+ * to access it.
+ */
+struct rcu_node {
+    unsigned int tid;
+    uintptr_t __next_rcu_nesting;
+} __rcu_aligned;
+
+struct rcu_data {
+    unsigned int nr_thread;
+    struct rcu_node *head;
+    unsigned int rcu_nesting_idx;
+    spinlock_t lock;
+};
+
+/* Helper macro of next pointer and rcu_nesting */
+
+#define rcu_nesting(np, idx) \
+    (READ_ONCE((np)->__next_rcu_nesting) & (0x1 << ((idx) & (0x1))))
+#define rcu_set_nesting(np, idx)                                             \
+    do {                                                                     \
+        WRITE_ONCE(                                                          \
+            (np)->__next_rcu_nesting,                                        \
+            READ_ONCE((np)->__next_rcu_nesting) | (0x1 << ((idx) & (0x1)))); \
+    } while (0)
+#define rcu_unset_nesting(np)                                          \
+    do {                                                               \
+        smp_store_release((np)->__next_rcu_nesting,                    \
+                          READ_ONCE((np)->__next_rcu_nesting) & ~0x3); \
+    } while (0)
+#define rcu_next(np) \
+    ((struct rcu_node *) (READ_ONCE((np)->__next_rcu_nesting) & ~0x3))
+#define rcu_next_mask(nrn) ((struct rcu_node *) ((uintptr_t) (nrn) & ~0x3))
+
+static struct rcu_data rcu_data = {
+    .nr_thread = 0,
+    .head = NULL,
+    .rcu_nesting_idx = 0,
+    .lock = SPINLOCK_INIT,
+};
+static __thread struct rcu_node *__rcu_per_thread_ptr;
+
+static inline struct rcu_node *__rcu_node_add(uintptr_t tid)
+{
+    struct rcu_node **indirect = &rcu_data.head;
+    struct rcu_node *node = malloc(sizeof(struct rcu_node));
+
+    if (!node) {
+        fprintf(stderr, "__rcu_node_add: malloc failed\n");
+        abort();
+    }
+
+    node->tid = tid;
+    node->__next_rcu_nesting = 0;
+
+    spin_lock(&rcu_data.lock);
+
+    /* Read-side will write the rcu_nesting field in __next_rcu_nesting
+     * even if we lock the linked list. So, here we use READ_ONCE().
+     */
+#define rro_mask(pp) rcu_next_mask(READ_ONCE((*pp)))
+
+    while (rro_mask(indirect)) {
+        if (rro_mask(indirect)->tid == node->tid) {
+            spin_unlock(&rcu_data.lock);
+            free(node);
+            return NULL;
+        }
+        indirect = (struct rcu_node **) &rro_mask(indirect)->__next_rcu_nesting;
+    }
+
+#undef rro_mask
+
+    atomic_fetch_or_release((uintptr_t *) indirect, (uintptr_t) node);
+    rcu_data.nr_thread++;
+
+    spin_unlock(&rcu_data.lock);
+
+    smp_mb();
+
+    return node;
+}
+
+static inline int rcu_init(void)
+{
+    uintptr_t tid = current_tid();
+
+    __rcu_per_thread_ptr = __rcu_node_add(tid);
+
+    return __rcu_per_thread_ptr ? 0 : -ENOMEM;
+}
+
+static inline void rcu_clean(void)
+{
+    struct rcu_node *node, *tmp;
+
+    spin_lock(&rcu_data.lock);
+
+    for (node = rcu_data.head; node; node = tmp) {
+        tmp = rcu_next_mask(node->__next_rcu_nesting);
+        free(rcu_next_mask(node));
+    }
+
+    rcu_data.head = NULL;
+    rcu_data.nr_thread = 0;
+
+    spin_unlock(&rcu_data.lock);
+}
+
+/* The per-thread reference count will only modified by their owner
+ * thread but will read by other threads. So here we use WRITE_ONCE().
+ *
+ * We can change the set 1/0 to reference count to make rcu read-side lock
+ * nesting. But here we simplified it to become once as time.
+ */
+static inline void rcu_read_lock(void)
+{
+    rcu_set_nesting(__rcu_per_thread_ptr, READ_ONCE(rcu_data.rcu_nesting_idx));
+}
+
+/* It uses the smp_store_release().
+ * But in some case, like MacOS (x86_64, M1), it can use WRITE_ONCE().
+ */
+static inline void rcu_read_unlock(void)
+{
+    rcu_unset_nesting(__rcu_per_thread_ptr);
+}
+
+static inline void synchronize_rcu(void)
+{
+    struct rcu_node *node;
+    int i;
+
+    smp_mb();
+
+    spin_lock(&rcu_data.lock);
+
+    /* When rcu_nesting is set, the thread is in the read-side critical
+     * section. It is safe to plain access rcu_data.rcu_nesting_idx since
+     * it only modified by the update-side.
+     *
+     * Again, if we want the read-side lock to be nesting, we need to change
+     * rcu_nesting to reference count.
+     */
+    for (node = rcu_data.head; node; node = rcu_next(node)) {
+        while (rcu_nesting(node, rcu_data.rcu_nesting_idx)) {
+            barrier();
+        }
+    }
+
+    /* Going to next grace period */
+    i = atomic_fetch_add_release(&rcu_data.rcu_nesting_idx, 1);
+
+    smp_mb();
+
+    /* Some read-side threads may be in the linked list, but it enters the
+     * read-side critical section after the update-side checks it's nesting.
+     * It may cause a data race since the update-side will think all the reader
+     * passes through the critical section.
+     * To stay away from it, we check again after increasing the global index
+     * variable.
+     */
+    for (node = rcu_data.head; node; node = rcu_next(node)) {
+        while (rcu_nesting(node, i)) {
+            barrier();
+        }
+    }
+
+    spin_unlock(&rcu_data.lock);
+
+    smp_mb();
+}
+
+#define rcu_dereference(p)                                                 \
+    ({                                                                     \
+        __typeof__(*p) *__r_d_p = (__typeof__(*p) __force *) READ_ONCE(p); \
+        rcu_check_sparse(p, __rcu);                                        \
+        __r_d_p;                                                           \
+    })
+
+#define rcu_assign_pointer(p, v)                                          \
+    ({                                                                    \
+        rcu_check_sparse(p, __rcu);                                       \
+        (__typeof__(*p) __force *) atomic_xchg_release((rcu_uncheck(&p)), \
+                                                       rcu_check(v));     \
+    })
+
+#endif /* __RCU_H__ */


### PR DESCRIPTION
Add the Linux Kernel style thread-based simple RCU.
It supports sparse checking [1].

With sparse, it will report:

```log
main.c: note: in included file:
thrd_rcu.h:95:42: warning: Using plain integer as NULL pointer
thrd_rcu.h:95:42: warning: Using plain integer as NULL pointer
```

It is from the pthread_mutex_t initializer, we can ignore it.

[1] https://www.kernel.org/doc/html/latest/dev-tools/sparse.html

---

From the [ThreadSanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual) report, ignore the `volatile` type data race warning [1][2],
there still have the data race warning.

```log
[reader 2835343104] 0
[reader 2826950400] 0
[reader 2818557696] 0
[reader 2810164992] 0
[reader 2801772288] 0
[updater 2793379584]
==================
WARNING: ThreadSanitizer: data race (pid=434539)
  Write of size 8 at 0x7b0400000000 by thread T6:
    #0 free ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:711 (libtsan.so.0+0x37ab8)
    #1 updater_side /home/xxxx/linux2021/concurrent-programs/thrd_rcu/main.c:41 (main+0x1a38)

  Previous read of size 4 at 0x7b0400000000 by thread T5:
    #0 reader_side /home/xxxx/linux2021/concurrent-programs/thrd_rcu/main.c:23 (main+0x1898)

  Thread T6 (tid=434546, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605f8)
    #1 main /home/xxxx/linux2021/concurrent-programs/thrd_rcu/main.c:59 (main+0x1429)

  Thread T5 (tid=434545, finished) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605f8)
    #1 main /home/xxxx/linux2021/concurrent-programs/thrd_rcu/main.c:56 (main+0x13fd)

SUMMARY: ThreadSanitizer: data race /home/xxxx/linux2021/concurrent-programs/thrd_rcu/main.c:41 in updater_side
==================
[reader 2784986880] 2793379584
[reader 2744121088] 2793379584
[reader 2735728384] 2793379584
[reader 2727335680] 2793379584
[reader 2718942976] 2793379584
ThreadSanitizer: reported 1 warnings
```

I try to debug it, but cannot figure out where the wrong is.
Not sure if it is a false positive or not.

[1] https://gcc.gnu.org/pipermail/gcc-patches/2020-June/547633.html
[2] https://gcc.gnu.org/gcc-11/changes.html