### PR TITLE
Fix grace period over bound checking

### DIFF
--- a/thread-rcu/main.c
+++ b/thread-rcu/main.c
@@ -71,7 +71,7 @@ static void *reader_func(void *argv)
         if (tmp->count != old_prev_count)
             atomic_fetch_add_explicit(&gp_idx, 1, memory_order_release);
         if (atomic_load_explicit(&gp_idx, memory_order_acquire) >
-            N_UPDATE_RUN + 1) {
+            N_UPDATE_RUN) {
             fprintf(stderr, "grace period index (%u) is over bound (%u).\n",
                     atomic_load_explicit(&gp_idx, memory_order_acquire),
                     N_UPDATE_RUN);


### PR DESCRIPTION
The array of the grace period will have the number update run + 1 of the
index. So the bound of the grace period is the number of update runs, not
update run + 1.