### PR TITLE
thread-rcu: Fix the types in rcu.h and barrier counter 

### DIFF
--- a/thread-rcu/main.c
+++ b/thread-rcu/main.c
@@ -23,6 +23,7 @@ static inline void thread_barrier(struct barrier_struct *b, size_t n)
     pthread_mutex_lock(&b->lock);
     b->count++;
     if (b->count == n) {
+        b->count = 0;
         pthread_mutex_unlock(&b->lock);
         atomic_store_explicit(&b->flag, local_sense, memory_order_release);
     } else {


### PR DESCRIPTION
rcu.h:
- Fix the parameter type of smp_store_release(). The parameter that
  wants to store should be a pointer type.
- Fix the type of tid in rcu_node.
- Rename all the internal parameters in Linux kernel style API to
  make it more prettier.

main.c:
- Fix the barrier counter that doesn't initialize after exit.

No function change.
