### PR TITLE
work-steal: fix incompatible pointer warning

### DIFF
--- a/work-steal/work-steal.c
+++ b/work-steal/work-steal.c
@@ -51,7 +51,7 @@ static work_t *EMPTY = (work_t *) 0x100, *ABORT = (work_t *) 0x200;
 
 typedef struct {
     atomic_size_t size;
-    _Atomic work_t *buffer[];
+    _Atomic(work_t *) buffer[];
 } array_t;
 
 typedef struct {


### PR DESCRIPTION
When building code, the compiler says:
```
work-steal.c: In function ‘take’:
work-steal.c:111:11: warning: assignment to ‘work_t *’ {aka ‘struct work_internal *’} from incompatible pointer type ‘_Atomic work_t *’ {aka ‘_Atomic struct work_internal *’} [-Wincompatible-pointer-types]
  111 |         x = atomic_load_explicit(&a->buffer[b % a->size], memory_order_relaxed);
      |           ^
work-steal.c: In function ‘push’:
work-steal.c:137:5: warning: initialization of ‘_Atomic work_t *’ {aka ‘_Atomic struct work_internal *’} from incompatible pointer type ‘work_t *’ {aka ‘struct work_internal *’} [-Wincompatible-pointer-types]
  137 |     atomic_store_explicit(&a->buffer[b % a->size], w, memory_order_relaxed);
      |     ^~~~~~~~~~~~~~~~~~~~~
work-steal.c: In function ‘steal’:
work-steal.c:151:11: warning: assignment to ‘work_t *’ {aka ‘struct work_internal *’} from incompatible pointer type ‘_Atomic work_t *’ {aka ‘_Atomic struct work_internal *’} [-Wincompatible-pointer-types]
  151 |         x = atomic_load_explicit(&a->buffer[t % a->size], memory_order_relaxed);
      |
```