### PR TITLE
Free task memory after completion

### DIFF
--- a/coro/coro.c
+++ b/coro/coro.c
@@ -104,6 +104,7 @@ void task0(void *arg)
     }
 
     printf("%s: complete\n", task->task_name);
+    free(task);
     longjmp(sched, 1);
 }
 
@@ -135,6 +136,7 @@ void task1(void *arg)
     }
 
     printf("%s: complete\n", task->task_name);
+    free(task);
     longjmp(sched, 1);
 }
 


### PR DESCRIPTION
Previously, tasks in coro.c were allocated using malloc but never freed, causing memory leaks.  
Added missing deallocation after task completion to resolve the issue.