### PR TITLE
remove unnecessary longjmp when task is last

### DIFF
--- a/coro/coro.c
+++ b/coro/coro.c
@@ -137,7 +137,6 @@ void task1(void *arg)
 
     printf("%s: complete\n", task->task_name);
     free(task);
-    longjmp(sched, 1);
 }
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))


### PR DESCRIPTION
Since task1 is the last task in the task queue, there is no need
to perform a longjmp(sched, 1) after it completes. Returning
directly avoids unnecessary scheduling logic and simplifies
control flow.