### PR TITLE
preempt_sched: use sa_sigaction for SA_SIGINFO

### DIFF
--- a/preempt_sched/task_sched.c
+++ b/preempt_sched/task_sched.c
@@ -166,7 +166,7 @@ static void task_add(task_callback_t *func, void *param)
     preempt_enable();
 }
 
-static void timer_handler(int signo, siginfo_t *info, ucontext_t *ctx)
+static void timer_handler(int signo, siginfo_t *info, void *ctx)
 {
     if (preempt_count) /* once preemption is disabled */
         return;
@@ -180,7 +180,7 @@ static void timer_handler(int signo, siginfo_t *info, ucontext_t *ctx)
 static void timer_init(void)
 {
     struct sigaction sa = {
-        .sa_handler = (void (*)(int)) timer_handler,
+        .sa_sigaction = timer_handler,
         .sa_flags = SA_SIGINFO,
     };
     sigfillset(&sa.sa_mask);


### PR DESCRIPTION
According to sigaction(2), when SA_SIGINFO is specified in sa_flags, the signal handler should be sa_sigaction instead of sa_handler.

timer_handler() uses the three-argument signal handler form, but the current code registers it through sa_handler by casting it to a one-argument handler type. Use sa_sigaction to match the documented API and avoid casting between incompatible function pointer types.

Reference:
https://man7.org/linux/man-pages/man2/sigaction.2.html

>If SA_SIGINFO is specified in sa_flags, then sa_sigaction (instead of sa_handler) specifies the signal-handling function for signum. This function receives three arguments, as described below.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use sa_sigaction for the timer signal when SA_SIGINFO is set, so the 3-arg handler is registered correctly. Also switch timer_handler’s third parameter to void* and remove the function-pointer cast, aligning with sigaction(2) and preventing undefined behavior.

<sup>Written for commit 4f9eae68be7473959ece8d2481aad896e52985b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/concurrent-programs/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

